### PR TITLE
test: enable remaining unit tests

### DIFF
--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -21,6 +21,10 @@ func TestRunRestoredDBExample(t *testing.T) {
 		TerraformVars: map[string]interface{}{
 			"mysql_version": "8.0",
 		},
+		ImplicitDestroy: []string{
+			"module.mysql_db.time_sleep.wait_for_authorization_policy",
+			"module.restored_mysql_db.time_sleep.wait_for_authorization_policy",
+		},
 	})
 
 	output, err := options.RunTestConsistency()
@@ -41,7 +45,9 @@ func TestRunPointInTimeRecoveryDBExample(t *testing.T) {
 			"pitr_id":       permanentResources["mysqlPITRCrn"],
 			"pitr_time":     " ",
 			"mysql_version": permanentResources["mysqlPITRVersion"],
-			"members":       "3", // Lock members to 3 as the permanent mysql instances has 3 members
+		},
+		ImplicitDestroy: []string{
+			"module.mysql_db_pitr.time_sleep.wait_for_authorization_policy",
 		},
 	})
 
@@ -61,6 +67,10 @@ func TestRunBasicExample(t *testing.T) {
 		ResourceGroup:      resourceGroup,
 		TerraformVars: map[string]interface{}{
 			"mysql_version": "8.0",
+		},
+		ImplicitDestroy: []string{
+			"module.mysql_db.time_sleep.wait_for_authorization_policy",
+			"module.read_only_replica_mysql_db[0].time_sleep.wait_for_authorization_policy",
 		},
 	})
 

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -2,6 +2,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,13 +28,6 @@ func TestRunRestoredDBExample(t *testing.T) {
 	assert.NotNil(t, output, "Expected some output")
 }
 
-/************************************************
-TO-DO: set up a permanent mysql with point-in-time
-This extra test can be enabled only after a permanent mysql is set up in test account
-and info is added to the resources yaml.
-NOTE: double check key values of permanentResources references
-*************************************************/
-/*
 func TestRunPointInTimeRecoveryDBExample(t *testing.T) {
 	t.Parallel()
 
@@ -44,10 +38,10 @@ func TestRunPointInTimeRecoveryDBExample(t *testing.T) {
 		ResourceGroup: resourceGroup,
 		Region:        fmt.Sprint(permanentResources["mysqlPITRRegion"]),
 		TerraformVars: map[string]interface{}{
-			"pitr_id":    permanentResources["mysqlPITRCrn"],
-			"pitr_time":  " ",
+			"pitr_id":       permanentResources["mysqlPITRCrn"],
+			"pitr_time":     " ",
 			"mysql_version": permanentResources["mysqlPITRVersion"],
-			"members":    "3", // Lock members to 3 as the permanent mysql instances has 3 members
+			"members":       "3", // Lock members to 3 as the permanent mysql instances has 3 members
 		},
 	})
 
@@ -55,7 +49,6 @@ func TestRunPointInTimeRecoveryDBExample(t *testing.T) {
 	assert.Nil(t, err, "This should not have errored")
 	assert.NotNil(t, output, "Expected some output")
 }
-*/
 
 func TestRunBasicExample(t *testing.T) {
 	t.Parallel()

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -58,6 +58,9 @@ func TestRunFSCloudExample(t *testing.T) {
 			"kms_key_crn":                permanentResources["hpcs_south_root_key_crn"],
 			"mysql_version":              "8.0", // Always lock this test into the latest supported mysql version
 		},
+		ImplicitDestroy: []string{
+			"module.mysql_db.time_sleep.wait_for_authorization_policy",
+		},
 	})
 	options.SkipTestTearDown = true
 	output, err := options.RunTestConsistency()
@@ -96,6 +99,9 @@ func TestRunUpgradeCompleteExample(t *testing.T) {
 				},
 			},
 			"admin_pass": randomPass,
+		},
+		ImplicitDestroy: []string{
+			"module.mysql_db.time_sleep.wait_for_authorization_policy",
 		},
 	})
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Use existing resource group
-const resourceGroup = "geretain-test-resources"
+const resourceGroup = "geretain-test-mysql"
 
 // Restricting due to limited availability of BYOK in certain regions
 const regionSelectionPath = "../common-dev-assets/common-go-assets/icd-region-prefs.yaml"


### PR DESCRIPTION
### Description

Enabled point-in-time test, which should complete all unit tests.

Also noticed that a `time_wait` in the base mysql module was not being skipped for destroy, added the ImplicitDestroy option for this which should speed up tests.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
