### PR TITLE
fix: changed `users` input to `Multiline secure value`

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -223,7 +223,15 @@
               "key": "admin_pass"
             },
             {
-              "key": "users"
+              "key": "users",
+              "custom_config": {
+                  "type": "multiline_secure_value",
+                  "grouping": "deployment",
+                  "original_grouping": "deployment",
+                  "config_constraints": {
+                      "type": "mixed"
+                  }
+              }
             },
             {
               "key": "tags"


### PR DESCRIPTION
### Description

https://github.ibm.com/GoldenEye/issues/issues/12988 

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This PR modifies `users` input to `Multiline secure value` type in the ibm_catalog.json

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
