### PR TITLE
fix: update DA inputs

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -290,7 +290,7 @@
               "key": "service_credential_secrets"
             },
             {
-              "key": "skip_mysql_sm_auth_policy"
+              "key": "skip_mysql_secrets_manager_auth_policy"
             },
             {
               "key": "skip_mysql_kms_auth_policy"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -299,13 +299,13 @@
               "key": "backup_crn"
             },
             {
-              "key": "admin_pass_secret_manager_secret_group"
+              "key": "admin_pass_secrets_manager_secret_group"
             },
             {
-              "key": "admin_pass_secret_manager_secret_name"
+              "key": "admin_pass_secrets_manager_secret_name"
             },
             {
-              "key": "use_existing_admin_pass_secret_manager_secret_group"
+              "key": "use_existing_admin_pass_secrets_manager_secret_group"
             },
             {
               "key": "existing_mysql_instance_crn"

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -314,7 +314,7 @@ locals {
 
 locals {
   ## Variable validation (approach based on https://github.com/hashicorp/terraform/issues/25609#issuecomment-1057614400)
-  create_sm_auth_policy = var.skip_mysql_sm_auth_policy || var.existing_secrets_manager_instance_crn == null ? 0 : 1
+  create_sm_auth_policy = var.skip_mysql_secrets_manager_auth_policy || var.existing_secrets_manager_instance_crn == null ? 0 : 1
 }
 
 # Parse the Secrets Manager CRN

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -369,10 +369,10 @@ locals {
 
   # Build the structure of the arbitrary credential type secret for admin password
   admin_pass_secret = [{
-    secret_group_name     = (var.prefix != null && var.prefix != "") && var.admin_pass_secret_manager_secret_group != null ? "${var.prefix}-${var.admin_pass_secret_manager_secret_group}" : var.admin_pass_secret_manager_secret_group
-    existing_secret_group = var.use_existing_admin_pass_secret_manager_secret_group
+    secret_group_name     = (var.prefix != null && var.prefix != "") && var.admin_pass_secrets_manager_secret_group != null ? "${var.prefix}-${var.admin_pass_secrets_manager_secret_group}" : var.admin_pass_secrets_manager_secret_group
+    existing_secret_group = var.use_existing_admin_pass_secrets_manager_secret_group
     secrets = [{
-      secret_name             = (var.prefix != null && var.prefix != "") && var.admin_pass_secret_manager_secret_name != null ? "${var.prefix}-${var.admin_pass_secret_manager_secret_name}" : var.admin_pass_secret_manager_secret_name
+      secret_name             = (var.prefix != null && var.prefix != "") && var.admin_pass_secrets_manager_secret_name != null ? "${var.prefix}-${var.admin_pass_secrets_manager_secret_name}" : var.admin_pass_secrets_manager_secret_name
       secret_type             = "arbitrary"
       secret_payload_password = local.admin_pass
       }

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -376,7 +376,7 @@ variable "service_credential_secrets" {
   }
 }
 
-variable "skip_mysql_sm_auth_policy" {
+variable "skip_mysql_secrets_manager_auth_policy" {
   type        = bool
   default     = false
   description = "Whether an IAM authorization policy is created for Secrets Manager instance to create a service credential secrets for Databases for MySQL. If set to false, the Secrets Manager instance passed by the user is granted the Key Manager access to the MySQL instance created by the Deployable Architecture. Set to `true` to use an existing policy. The value of this is ignored if any value for 'existing_secrets_manager_instance_crn' is not passed."

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -382,28 +382,28 @@ variable "skip_mysql_sm_auth_policy" {
   description = "Whether an IAM authorization policy is created for Secrets Manager instance to create a service credential secrets for Databases for MySQL. If set to false, the Secrets Manager instance passed by the user is granted the Key Manager access to the MySQL instance created by the Deployable Architecture. Set to `true` to use an existing policy. The value of this is ignored if any value for 'existing_secrets_manager_instance_crn' is not passed."
 }
 
-variable "admin_pass_secret_manager_secret_group" {
+variable "admin_pass_secrets_manager_secret_group" {
   type        = string
-  description = "The name of a new or existing secrets manager secret group for admin password. To use existing secret group, `use_existing_admin_pass_secret_manager_secret_group` must be set to `true`. If a prefix input variable is specified, the prefix is added to the name in the `<prefix>-<name>` format."
+  description = "The name of a new or existing secrets manager secret group for admin password. To use existing secret group, `use_existing_admin_pass_secrets_manager_secret_group` must be set to `true`. If a prefix input variable is specified, the prefix is added to the name in the `<prefix>-<name>` format."
   default     = "mysql-secrets"
 
   validation {
     condition = (
       var.existing_secrets_manager_instance_crn == null ||
-      var.admin_pass_secret_manager_secret_group != null
+      var.admin_pass_secrets_manager_secret_group != null
     )
-    error_message = "`admin_pass_secret_manager_secret_group` is required when `existing_secrets_manager_instance_crn` is set."
+    error_message = "`admin_pass_secrets_manager_secret_group` is required when `existing_secrets_manager_instance_crn` is set."
   }
 }
 
-variable "use_existing_admin_pass_secret_manager_secret_group" {
+variable "use_existing_admin_pass_secrets_manager_secret_group" {
   type        = bool
   description = "Whether to use an existing secrets manager secret group for admin password."
   default     = false
 
 }
 
-variable "admin_pass_secret_manager_secret_name" {
+variable "admin_pass_secrets_manager_secret_name" {
   type        = string
   description = "The name of a new redis administrator secret. If a prefix input variable is specified, the prefix is added to the name in the `<prefix>-<name>` format."
   default     = "mysql-admin-password"
@@ -411,8 +411,8 @@ variable "admin_pass_secret_manager_secret_name" {
   validation {
     condition = (
       var.existing_secrets_manager_instance_crn == null ||
-      var.admin_pass_secret_manager_secret_name != null
+      var.admin_pass_secrets_manager_secret_name != null
     )
-    error_message = "`admin_pass_secret_manager_secret_name` is required when `existing_secrets_manager_instance_crn` is set."
+    error_message = "`admin_pass_secrets_manager_secret_name` is required when `existing_secrets_manager_instance_crn` is set."
   }
 }


### PR DESCRIPTION
### Description

The following variables are named inconsistently/incorrectly:

- skip_mysql_sm_auth_policy
- admin_pass_secret_manager_secret_group
- use_existing_admin_pass_secret_manager_secret_group
- admin_pass_secret_manager_secret_name

They are correctly renamed for Secrets Manager

- skip_mysql_secrets_manager_auth_policy
- admin_pass_secrets_manager_secret_group
- use_existing_admin_pass_secrets_manager_secret_group
- admin_pass_secrets_manager_secret_name

Is this a minor release, or a major release changing inputs in the DA?

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Inputs to the deployable architecture need updating. The following inputs are corrected, adding an `s` to make it secrets_manager.

- skip_mysql_sm_auth_policy becomes skip_mysql_secrets_manager_auth_policy
- admin_pass_secret_manager_secret_group becomes admin_pass_secrets_manager_secret_group
- use_existing_admin_pass_secret_manager_secret_group becomes use_existing_admin_pass_secrets_manager_secret_group
- admin_pass_secret_manager_secret_name becomes admin_pass_secrets_manager_secret_name

If the DA is being consumed as code, terraform inputs will need updating before plan and apply can be run.
If the DA is being consumed via projects/schematics the old value with have to be put in the new property in the UI.

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
