### PR TITLE
feat: use code editor for auto scale configuration

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -259,7 +259,12 @@
               "key": "member_host_flavor"
             },
             {
-              "key": "auto_scaling"
+              "key": "auto_scaling",
+              "custom_config": {
+                "type": "code_editor",
+                "grouping": "deployment",
+                "original_grouping": "deployment"
+              }
             },
             {
               "key": "configuration",
@@ -600,7 +605,12 @@
               "key": "member_host_flavor"
             },
             {
-              "key": "auto_scaling"
+              "key": "auto_scaling",
+              "custom_config": {
+                "type": "code_editor",
+                "grouping": "deployment",
+                "original_grouping": "deployment"
+              }
             },
             {
               "key": "configuration",

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -360,7 +360,28 @@ variable "auto_scaling" {
     })
   })
   description = "Optional rules to allow the database to increase resources in response to usage. Only a single autoscaling block is allowed. Make sure you understand the effects of autoscaling, especially for production environments. [Learn more](https://github.com/terraform-ibm-modules/terraform-ibm-icd-mysql/blob/main/solutions/fully-configurable/DA-types.md#autoscaling)"
-  default     = null
+  default = {
+    disk = {
+      capacity_enabled             = false
+      free_space_less_than_percent = 10
+      io_above_percent             = 90
+      io_enabled                   = false
+      io_over_period               = "15m"
+      rate_increase_percent        = 10
+      rate_limit_mb_per_member     = 3670016
+      rate_period_seconds          = 900
+      rate_units                   = "mb"
+    }
+    memory = {
+      io_above_percent         = 90
+      io_enabled               = false
+      io_over_period           = "15m"
+      rate_increase_percent    = 10
+      rate_limit_mb_per_member = 114688
+      rate_period_seconds      = 900
+      rate_units               = "mb"
+    }
+  }
 }
 
 #############################################################################

--- a/solutions/security-enforced/variables.tf
+++ b/solutions/security-enforced/variables.tf
@@ -297,7 +297,28 @@ variable "auto_scaling" {
     })
   })
   description = "Optional rules to allow the database to increase resources in response to usage. Only a single autoscaling block is allowed. Make sure you understand the effects of autoscaling, especially for production environments. [Learn more](https://github.com/terraform-ibm-modules/terraform-ibm-icd-mysql/blob/main/solutions/fully-configurable/DA-types.md#autoscaling)"
-  default     = null
+  default = {
+    disk = {
+      capacity_enabled             = false
+      free_space_less_than_percent = 10
+      io_above_percent             = 90
+      io_enabled                   = false
+      io_over_period               = "15m"
+      rate_increase_percent        = 10
+      rate_limit_mb_per_member     = 3670016
+      rate_period_seconds          = 900
+      rate_units                   = "mb"
+    }
+    memory = {
+      io_above_percent         = 90
+      io_enabled               = false
+      io_over_period           = "15m"
+      rate_increase_percent    = 10
+      rate_limit_mb_per_member = 114688
+      rate_period_seconds      = 900
+      rate_units               = "mb"
+    }
+  }
 }
 
 #############################################################################


### PR DESCRIPTION
### Description

Feature to set the deployable architecture auto scale input to use the code editor and provide a default value.

There are no migration issues, either
- an override is specified, in which case the existing one will still be used.
or
- no override is specified, in which case one will be added that matches the value already in the state file.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
